### PR TITLE
Added a bit of whitespace to partial expression prompt.

### DIFF
--- a/prolog/metta_lang/metta_repl.pl
+++ b/prolog/metta_lang/metta_repl.pl
@@ -639,7 +639,8 @@ repl_read_next(Accumulated, Expr) :-
     % Read a line from the current input stream.
     read_line_to_string(current_input, Line),
     % switch prompts after the first line is read
-    prompt(_,'|'),
+    format(atom(T),'| ~t',[]),
+    prompt(_,T),
     % Call repl_read_next with the new line concatenated to the accumulated input.
     repl_read_next(Accumulated, Line, Expr).
 


### PR DESCRIPTION
* Makes the expression following the "|" more readable. We might want to do the same for the default metta+> prompt.