### PR TITLE
Compilation dierectives to avoid editline/readline errors on windows.

### DIFF
--- a/prolog/metta_lang/metta_repl.pl
+++ b/prolog/metta_lang/metta_repl.pl
@@ -152,6 +152,10 @@ check_file_exists_for_append(HistoryFile) :-
 %     ?- save_history.
 %     true.
 %
+:- if(is_win64).
+% Dummy to avoid errors on windows.
+save_history.
+:- else.
 save_history :-
     % Get the current input stream.
     current_input(Input),
@@ -163,6 +167,7 @@ save_history :-
     ;
         % Otherwise, do nothing.
         true).
+:- endif.
 
 %! load_and_trim_history is det.
 %   Loads and trims the REPL history if needed, and installs readline support.
@@ -2038,12 +2043,16 @@ interact(Variables, Goal, Tracing) :-
 %   This installs readline/editline support, allowing for line editing and history during input.
 :- dynamic(is_installed_readline_editline/1).
 :- volatile(is_installed_readline_editline/1).
+
+:- if(is_win64).
+:-else.
 install_readline_editline :-
     % Get the current input stream.
     current_input(Input),
     % Install readline support for the current input.
     install_readline(Input),
     !.
+:- endif.
 
 %!  el_wrap_metta(+Input) is det.
 %


### PR DESCRIPTION
* On linux, swipl uses one of two libraries to manage command line input: library(editline) or library(readline). Those libraries are not found under windows (library(editline) depends on libedit which is not compiled for windows) and SWI-Prolog uses a different mechanism to manage command line input. Mettalog expects one of the two libraries to be loaded and that causes errors to be raised at startup, on windows. The current commit avoids loading the two missing libraries and allows mettalog to be loaded without errors on windows.